### PR TITLE
fix: watch list for imports depending on `options.paths`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export const lessLoader = (options: Less.Options = {}, loaderOptions: LoaderOpti
         const filePath = path.resolve(process.cwd(), path.relative(process.cwd(), args.resolveDir), args.path);
         return {
           path: filePath,
-          watchFiles: [filePath, ...getLessImports(filePath)],
+          watchFiles: [filePath, ...getLessImports(filePath, (options.paths || []))],
         };
       });
 


### PR DESCRIPTION
This change is necessary since the file watcher is broken for those import paths that differ from the default import path. In other words, the current implementation of the file watcher doesn't consider additional import paths provided by the `Options.path?` interface member (though the loader does!).

This change implements an algorithm that checks for file existence at the default import path. If a file does not exist at the default import path, provided additional import paths are then considered. If one is found, the path is updated for the watcher's list by way of `getLessImports`. The fallback and default filepath used is always the default import path.