### PR TITLE
Initial (Less) CSS Module support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,8 @@ export const lessLoader = (options: Less.Options = {}, loaderOptions: LoaderOpti
         const content = await fs.readFile(args.path, 'utf-8');
         const dir = path.dirname(args.path);
 
+        const isModule = path.basename(args.path).endsWith('.module.less');
+
         const opts: Less.Options = {
           filename: args.path,
           relativeUrls: true,
@@ -49,7 +51,7 @@ export const lessLoader = (options: Less.Options = {}, loaderOptions: LoaderOpti
 
           return {
             contents: result.css,
-            loader: 'css',
+            loader: isModule ? 'local-css' : 'css',
             resolveDir: dir,
           };
         } catch (e) {


### PR DESCRIPTION
This patch adds support for `Less` flavored [CSS Module](https://github.com/css-modules/css-modules) support via ESBuild's CSS Module support. Support is extremely barebones, just enough to get it working. 

### How to use it
Create a file with a `.module.less` file extension.
```css
/* style.module.less */
/* these names will change */
.someLocal {
    display: block;
}

:local .some-explicit-local {
    display: inline;
}

/* this will not change */
:global .some-global {
    font-weight: bold;
}
```

You can now import the `.less` file as if it was a javascript module.

```js
import styles from './style.module.css';             // import all locals
import { someLocal } from './style.module.css';      // import specific locals

console.log("styles =", styles);
```

The values will be mangled names used by the bundler/minifier.

```js
styles = {
    "someLocal": "style_module_someLocal",
    "some-explicit-local": "style_module_some-explicit-local"
}
```

The resulting bundled CSS output will match accordingly.

```css
/* style.module.css */
.style_module_someLocal {
    display: block;
}

.style_module_some-explicit-local {
    display: inline;
}

.some-global {
    font-weight: bold;
}
```

And now ESBuild can help you both avoid name conflicts, and minify CSS class names.

### VSCode & Typescript tip
To stop the Typescript compiler from complaining, you can add this to any `.d.ts` file.

```ts
declare module "*.module.less";
```