### PR TITLE
fix: handle recursive imports

### DIFF
--- a/__tests__/less-utils.test.ts
+++ b/__tests__/less-utils.test.ts
@@ -7,6 +7,7 @@ describe('less-utils', () => {
     const filePath = path.resolve(__dirname, '../example/styles/style.less');
     const imports = getLessImports(filePath);
 
+    expect(imports).toHaveLength(5);
     expect(imports).toEqual(
       expect.arrayContaining([
         expect.stringContaining('styles/style-2.less'),
@@ -22,6 +23,7 @@ describe('less-utils', () => {
     const filePath = path.resolve(__dirname, '../example/styles/style.less');
     const imports = getLessImports(filePath, ['../example', '../example/styles']);
 
+    expect(imports).toHaveLength(5);
     expect(imports).toEqual(
       expect.arrayContaining([
         expect.stringContaining('styles/style-2.less'),
@@ -31,6 +33,28 @@ describe('less-utils', () => {
         expect.stringContaining('styles/without-ext.less'),
       ]),
     );
+  });
+
+  it('works with recursive imports', () => {
+    const filePath = path.resolve(__dirname, '../example/styles/recursive/a.less');
+    const imports = getLessImports(filePath);
+
+    expect(imports).toHaveLength(2);
+    expect(imports).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('styles/recursive/a.less'),
+        expect.stringContaining('styles/recursive/b.less'),
+      ]),
+    );
+  });
+
+  it('do not process a file if it has already been processed', () => {
+    const filePath = path.resolve(__dirname, '../example/styles/recursive/a.less');
+    const visited = new Set<string>();
+    visited.add(filePath);
+
+    const imports = getLessImports(filePath, [], visited);
+    expect(imports).toHaveLength(0);
   });
 
   it('get imports paths fail', () => {

--- a/example/styles/recursive/a.less
+++ b/example/styles/recursive/a.less
@@ -1,0 +1,5 @@
+@import 'b.less';
+
+body {
+  color: red;
+}

--- a/example/styles/recursive/b.less
+++ b/example/styles/recursive/b.less
@@ -1,0 +1,5 @@
+@import 'a.less';
+
+body {
+  background-color: blue;
+}

--- a/src/less-utils.ts
+++ b/src/less-utils.ts
@@ -9,8 +9,13 @@ const importCommentRegex = /(?:\/\*(?:[\s\S]*?)\*\/)|(\/\/(?:.*)$)/gm;
 const extWhitelist = ['.css', '.less'];
 
 /** Recursively get .less/.css imports from file */
-export function getLessImports(filePath: string, paths: string[] = []): string[] {
+export function getLessImports(filePath: string, paths: string[] = [], visited: Set<string> = new Set()): string[] {
   try {
+    if (visited.has(filePath)) {
+      return [];
+    }
+    visited.add(filePath);
+
     const dir = path.dirname(filePath);
     const content = fs.readFileSync(filePath).toString('utf8');
 
@@ -45,7 +50,7 @@ export function getLessImports(filePath: string, paths: string[] = []): string[]
       });
 
     const recursiveImports = fileImports.reduce((result, el) => {
-      return [...result, ...getLessImports(el, paths)];
+      return [...result, ...getLessImports(el, paths, visited)];
     }, fileImports);
 
     const result = recursiveImports.filter((el) => extWhitelist.includes(path.extname(el).toLowerCase()));


### PR DESCRIPTION
Added tracking handler for imported files to avoid infinite loops with recursive imports.

Closes https://github.com/iam-medvedev/esbuild-plugin-less/issues/114